### PR TITLE
Copy the currentContext into the cache when it's still valid

### DIFF
--- a/lib/HappyFSCache.js
+++ b/lib/HappyFSCache.js
@@ -38,6 +38,7 @@ module.exports = function HappyFSCache(id, cachePath) {
 
       if (toJSON(oldCache.context) === toJSON(currentContext)) {
         cache.mtimes = oldCache.mtimes;
+        cache.context = currentContext;
 
         var staleEntryCount = removeStaleEntries(cache.mtimes);
 


### PR DESCRIPTION
This fixes a problem where the cache was lost after a successful pickup of the cache. So to repro:
1. Run with happypack, generate cache
2. Run again, see the cache get picked up
3. Run again, see the cache go missing

With this patch, 3 successfully picks up the cache
